### PR TITLE
Removes pipx and ensures Tactile and Just Perfection are installed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ getting up to speed and configurations for them and gnome.
 
 To get started, download the setup tool and run setup.sh after a fresh install:
 
+Before starting, make sure to install [Tactile](#tactile) and [Just
+Perfection](#just-perfection) before continuing until we figure out how to
+install gnome extensions via a CLI tool.
+
 ```console
 wget [insert download]
 unzip -d ~/.local/rhelinit [insert zipfile.zip]

--- a/install/20_gnome-extensions.sh
+++ b/install/20_gnome-extensions.sh
@@ -5,14 +5,6 @@
 
 printf "Configuring Gnome Extensions...\n\n"
 
-#pipx not in normal repo.  Need EPEL for it. Removing for now.
-#sudo dnf install pipx -y
-#pipx install gnome-extensions-cli --system-site-packages
-
-# Install new extensions
-#gext install tactile@lundal.io
-#gext install just-perfection-desktop@just-perfection
-
 tactile_schema="$HOME/.local/share/gnome-shell/extensions/tactile@lundal.io/schemas/org.gnome.shell.extensions.tactile.gschema.xml"
 justper_schema="$HOME/.local/share/gnome-shell/extensions/just-perfection-desktop@just-perfection/schemas/org.gnome.shell.extensions.just-perfection.gschema.xml"
 

--- a/install/20_gnome-extensions.sh
+++ b/install/20_gnome-extensions.sh
@@ -10,9 +10,9 @@ justper_schema="$HOME/.local/share/gnome-shell/extensions/just-perfection-deskto
 
 if [ -f $tactile_schema ] && [ -f $justper_schema ]; then
 	#Setup schemas
-	sudo cp $tactile_schema /usr/share/glib-2.0/schemas
-	sudo cp $justper_schema /usr/share/glib-2.0/schemas
-	sudo glib-compile-schemas /usr/share/glib-2.0/schemas/
+	sudo cp $tactile_schema $HOME/.local/share/glib-2.0/schemas
+	sudo cp $justper_schema $HOME/.local/share/glib-2.0/schemas
+	glib-compile-schemas $HOME/.local/share/glib-2.0/schemas/
 
 	# Tactile Setup:
 	gsettings set org.gnome.shell.extensions.tactile col-0 1

--- a/install/20_gnome-extensions.sh
+++ b/install/20_gnome-extensions.sh
@@ -5,29 +5,36 @@
 
 printf "Configuring Gnome Extensions...\n\n"
 
-sudo dnf install pipx -y
-pipx install gnome-extensions-cli --system-site-packages
+#pipx not in normal repo.  Need EPEL for it. Removing for now.
+#sudo dnf install pipx -y
+#pipx install gnome-extensions-cli --system-site-packages
 
 # Install new extensions
-gext install tactile@lundal.io
-gext install just-perfection-desktop@just-perfection
+#gext install tactile@lundal.io
+#gext install just-perfection-desktop@just-perfection
 
-#Setup schemas
-sudo cp ~/.local/share/gnome-shell/extensions/tactile@lundal.io/schemas/org.gnome.shell.extensions.tactile.gschema.xml /usr/share/glib-2.0/schemas
-sudo cp ~/.local/share/gnome-shell/extensions/just-perfection-desktop@just-perfection/schemas/org.gnome.shell.extensions.just-perfection.gschema.xml /usr/share/glib-2.0/schemas
-sudo glib-compile-schemas /usr/share/glib-2.0/schemas/
+tactile_schema="~/.local/share/gnome-shell/extensions/tactile@lundal.io/schemas/org.gnome.shell.extensions.tactile.gschema.xml"
+justper_schema="~/.local/share/gnome-shell/extensions/just-perfection-desktop@just-perfection/schemas/org.gnome.shell.extensions.just-perfection.gschema.xml"
 
-# Tactile Setup:
-gsettings set org.gnome.shell.extensions.tactile col-0 1
-gsettings set org.gnome.shell.extensions.tactile col-1 2
-gsettings set org.gnome.shell.extensions.tactile col-2 1
-gsettings set org.gnome.shell.extensions.tactile col-3 0
-gsettings set org.gnome.shell.extensions.tactile row-0 1
-gsettings set org.gnome.shell.extensions.tactile row-1 1
-gsettings set org.gnome.shell.extensions.tactile gap-size 32
+if [ -f $tactile_schema ] && [ -f $justper_schema ]; then
+	#Setup schemas
+	sudo cp ~/.local/share/gnome-shell/extensions/tactile@lundal.io/schemas/org.gnome.shell.extensions.tactile.gschema.xml /usr/share/glib-2.0/schemas
+	sudo cp ~/.local/share/gnome-shell/extensions/just-perfection-desktop@just-perfection/schemas/org.gnome.shell.extensions.just-perfection.gschema.xml /usr/share/glib-2.0/schemas
+	sudo glib-compile-schemas /usr/share/glib-2.0/schemas/
 
-# Configure Just Perfection
-gsettings set org.gnome.shell.extensions.just-perfection animation 2
-gsettings set org.gnome.shell.extensions.just-perfection dash-app-running true
-gsettings set org.gnome.shell.extensions.just-perfection workspace true
-gsettings set org.gnome.shell.extensions.just-perfection workspace-popup false
+	# Tactile Setup:
+	gsettings set org.gnome.shell.extensions.tactile col-0 1
+	gsettings set org.gnome.shell.extensions.tactile col-1 2
+	gsettings set org.gnome.shell.extensions.tactile col-2 1
+	gsettings set org.gnome.shell.extensions.tactile col-3 0
+	gsettings set org.gnome.shell.extensions.tactile row-0 1
+	gsettings set org.gnome.shell.extensions.tactile row-1 1
+	gsettings set org.gnome.shell.extensions.tactile gap-size 32
+
+	# Configure Just Perfection
+	gsettings set org.gnome.shell.extensions.just-perfection animation 2
+	gsettings set org.gnome.shell.extensions.just-perfection dash-app-running true
+	gsettings set org.gnome.shell.extensions.just-perfection workspace true
+	gsettings set org.gnome.shell.extensions.just-perfection workspace-popup false
+else
+	printf "\n\nTactile and Just Perfection not installed\nInstall them first\n\n"

--- a/install/20_gnome-extensions.sh
+++ b/install/20_gnome-extensions.sh
@@ -13,13 +13,13 @@ printf "Configuring Gnome Extensions...\n\n"
 #gext install tactile@lundal.io
 #gext install just-perfection-desktop@just-perfection
 
-tactile_schema="~/.local/share/gnome-shell/extensions/tactile@lundal.io/schemas/org.gnome.shell.extensions.tactile.gschema.xml"
-justper_schema="~/.local/share/gnome-shell/extensions/just-perfection-desktop@just-perfection/schemas/org.gnome.shell.extensions.just-perfection.gschema.xml"
+tactile_schema="$HOME/.local/share/gnome-shell/extensions/tactile@lundal.io/schemas/org.gnome.shell.extensions.tactile.gschema.xml"
+justper_schema="$HOME/.local/share/gnome-shell/extensions/just-perfection-desktop@just-perfection/schemas/org.gnome.shell.extensions.just-perfection.gschema.xml"
 
 if [ -f $tactile_schema ] && [ -f $justper_schema ]; then
 	#Setup schemas
-	sudo cp ~/.local/share/gnome-shell/extensions/tactile@lundal.io/schemas/org.gnome.shell.extensions.tactile.gschema.xml /usr/share/glib-2.0/schemas
-	sudo cp ~/.local/share/gnome-shell/extensions/just-perfection-desktop@just-perfection/schemas/org.gnome.shell.extensions.just-perfection.gschema.xml /usr/share/glib-2.0/schemas
+	sudo cp $tactile_schema /usr/share/glib-2.0/schemas
+	sudo cp $justper_schema /usr/share/glib-2.0/schemas
 	sudo glib-compile-schemas /usr/share/glib-2.0/schemas/
 
 	# Tactile Setup:
@@ -29,7 +29,7 @@ if [ -f $tactile_schema ] && [ -f $justper_schema ]; then
 	gsettings set org.gnome.shell.extensions.tactile col-3 0
 	gsettings set org.gnome.shell.extensions.tactile row-0 1
 	gsettings set org.gnome.shell.extensions.tactile row-1 1
-	gsettings set org.gnome.shell.extensions.tactile gap-size 32
+	gsettings set org.gnome.shell.extensions.tactile gap-size 15
 
 	# Configure Just Perfection
 	gsettings set org.gnome.shell.extensions.just-perfection animation 2
@@ -38,3 +38,4 @@ if [ -f $tactile_schema ] && [ -f $justper_schema ]; then
 	gsettings set org.gnome.shell.extensions.just-perfection workspace-popup false
 else
 	printf "\n\nTactile and Just Perfection not installed\nInstall them first\n\n"
+fi


### PR DESCRIPTION
Pipx is not available from RHEL default repos.  While it allows an easy way to get gext to download gnome extensions, it is difficult to get installed depending on content views and available repos for RHEL.  Will need a new way to install extensions from the command line.