### PR TITLE
Add .rhelinit_complete check file and logic

### DIFF
--- a/install/00_app-fonts.sh
+++ b/install/00_app-fonts.sh
@@ -1,21 +1,25 @@
 #!/bin/bash
 # This sets up gnome on RHEL 9 for my settings.
 
-printf "Installing Fonts...\n\n"
+if [ -f "$HOME/.rhelinit_complete" ]; then
+	printf "\nINFO: Skipping font installation. Remove %s to run configuration\n\n" "$HOME/.rhelinit_complete"
+else
+	printf "Installing Fonts...\n\n"
 
-# Setup fonts
-mkdir -p ~/.local/share/fonts
+	# Setup fonts
+	mkdir -p ~/.local/share/fonts
 
-cd /tmp
-wget https://github.com/ryanoasis/nerd-fonts/releases/latest/download/DejaVuSansMono.zip
-unzip DejaVuSansMono.zip -d DejaVuSansFont
-cp DejaVuSansFont/*.ttf ~/.local/share/fonts
-rm -rf DejaVuSansMono.zip DejaVuSansFont
+	cd /tmp || exit 3
+	wget https://github.com/ryanoasis/nerd-fonts/releases/latest/download/DejaVuSansMono.zip
+	unzip DejaVuSansMono.zip -d DejaVuSansFont
+	cp DejaVuSansFont/*.ttf ~/.local/share/fonts
+	rm -rf DejaVuSansMono.zip DejaVuSansFont
 
-wget https://github.com/ryanoasis/nerd-fonts/releases/latest/download/CascadiaMono.zip
-unzip CascadiaMono.zip -d CascadiaFont
-cp CascadiaFont/*.ttf ~/.local/share/fonts
-rm -rf CascadiaMono.zip CascadiaFont
+	wget https://github.com/ryanoasis/nerd-fonts/releases/latest/download/CascadiaMono.zip
+	unzip CascadiaMono.zip -d CascadiaFont
+	cp CascadiaFont/*.ttf ~/.local/share/fonts
+	rm -rf CascadiaMono.zip CascadiaFont
 
-fc-cache
-cd -
+	fc-cache
+	cd - || exit 3
+fi

--- a/install/00_homedir-setup.sh
+++ b/install/00_homedir-setup.sh
@@ -1,16 +1,20 @@
 #!/bin/bash
 
-mkdir -p ~/projects
-mkdir -p ~/bin
-
-# Basic Git Config
-git_config="./config/gitconfig"
-if [ -f $git_config ]; then
-	if [ ! -f $HOME/.gitconfig ]; then
-		cp $git_config ~/.gitconfig
-	else
-		printf "\n\nExisting git configuration found\n\n"
-	fi
+if [ -f "$HOME/.rhelinit_complete" ]; then
+	printf "\nINFO: Skipping Home Directory Setup. Remove %s to run configuration\n\n" "$HOME/.rhelinit_complete"
 else
-	printf "\n\n\Git config not found.\n\n"
+	mkdir -p ~/projects
+	mkdir -p ~/bin
+
+	# Basic Git Config
+	git_config="./config/gitconfig"
+	if [ -f $git_config ]; then
+		if [ ! -f $HOME/.gitconfig ]; then
+			cp $git_config ~/.gitconfig
+		else
+			printf "\n\nExisting git configuration found\n\n"
+		fi
+	else
+		printf "\n\n\Git config not found.\n\n"
+	fi
 fi

--- a/install/20_gnome-configure.sh
+++ b/install/20_gnome-configure.sh
@@ -1,33 +1,36 @@
 #!/bin/bash
 
-printf "Configuring Gnome Settings...\n\n"
+if [ -f "$HOME/.rhelinit_complete" ]; then
+	printf "\nINFO: Skipping Gnome settings. Remove %s to run configuration\n\n" "$HOME/.rhelinit_complete"
+else
+	printf "Configuring Gnome Settings...\n\n"
 
-# Set DejaVuSansM Mono as the default monospace font
-gsettings set org.gnome.desktop.interface monospace-font-name 'DejaVuSansM Nerd Font Mono'
+	# Set DejaVuSansM Mono as the default monospace font
+	gsettings set org.gnome.desktop.interface monospace-font-name 'DejaVuSansM Nerd Font Mono'
 
-# Set caps lock key to be ctr key
-gsettings set org.gnome.desktop.input-sources xkb-options "['caps:ctrl_modifier']"
+	# Set caps lock key to be ctr key
+	gsettings set org.gnome.desktop.input-sources xkb-options "['caps:ctrl_modifier']"
 
-# Use 6 fixed workspaces instead of dynamic mode
-gsettings set org.gnome.mutter dynamic-workspaces false
-gsettings set org.gnome.desktop.wm.preferences num-workspaces 6
+	# Use 6 fixed workspaces instead of dynamic mode
+	gsettings set org.gnome.mutter dynamic-workspaces false
+	gsettings set org.gnome.desktop.wm.preferences num-workspaces 6
 
-# Use alt for pinned apps
-gsettings set org.gnome.shell.keybindings switch-to-application-1 "['<Alt>1']"
-gsettings set org.gnome.shell.keybindings switch-to-application-2 "['<Alt>2']"
-gsettings set org.gnome.shell.keybindings switch-to-application-3 "['<Alt>3']"
-gsettings set org.gnome.shell.keybindings switch-to-application-4 "['<Alt>4']"
-gsettings set org.gnome.shell.keybindings switch-to-application-5 "['<Alt>5']"
-gsettings set org.gnome.shell.keybindings switch-to-application-6 "['<Alt>6']"
-gsettings set org.gnome.shell.keybindings switch-to-application-7 "['<Alt>7']"
-gsettings set org.gnome.shell.keybindings switch-to-application-8 "['<Alt>8']"
-gsettings set org.gnome.shell.keybindings switch-to-application-9 "['<Alt>9']"
+	# Use alt for pinned apps
+	gsettings set org.gnome.shell.keybindings switch-to-application-1 "['<Alt>1']"
+	gsettings set org.gnome.shell.keybindings switch-to-application-2 "['<Alt>2']"
+	gsettings set org.gnome.shell.keybindings switch-to-application-3 "['<Alt>3']"
+	gsettings set org.gnome.shell.keybindings switch-to-application-4 "['<Alt>4']"
+	gsettings set org.gnome.shell.keybindings switch-to-application-5 "['<Alt>5']"
+	gsettings set org.gnome.shell.keybindings switch-to-application-6 "['<Alt>6']"
+	gsettings set org.gnome.shell.keybindings switch-to-application-7 "['<Alt>7']"
+	gsettings set org.gnome.shell.keybindings switch-to-application-8 "['<Alt>8']"
+	gsettings set org.gnome.shell.keybindings switch-to-application-9 "['<Alt>9']"
 
-# Use super for workspaces
-gsettings set org.gnome.desktop.wm.keybindings switch-to-workspace-1 "['<Super>1']"
-gsettings set org.gnome.desktop.wm.keybindings switch-to-workspace-2 "['<Super>2']"
-gsettings set org.gnome.desktop.wm.keybindings switch-to-workspace-3 "['<Super>3']"
-gsettings set org.gnome.desktop.wm.keybindings switch-to-workspace-4 "['<Super>4']"
-gsettings set org.gnome.desktop.wm.keybindings switch-to-workspace-5 "['<Super>5']"
-gsettings set org.gnome.desktop.wm.keybindings switch-to-workspace-6 "['<Super>6']"
-
+	# Use super for workspaces
+	gsettings set org.gnome.desktop.wm.keybindings switch-to-workspace-1 "['<Super>1']"
+	gsettings set org.gnome.desktop.wm.keybindings switch-to-workspace-2 "['<Super>2']"
+	gsettings set org.gnome.desktop.wm.keybindings switch-to-workspace-3 "['<Super>3']"
+	gsettings set org.gnome.desktop.wm.keybindings switch-to-workspace-4 "['<Super>4']"
+	gsettings set org.gnome.desktop.wm.keybindings switch-to-workspace-5 "['<Super>5']"
+	gsettings set org.gnome.desktop.wm.keybindings switch-to-workspace-6 "['<Super>6']"
+fi

--- a/install/20_gnome-extensions.sh
+++ b/install/20_gnome-extensions.sh
@@ -3,31 +3,35 @@
 # tactile
 # just-perfection-desktop
 
-printf "Configuring Gnome Extensions...\n\n"
-
-tactile_schema="$HOME/.local/share/gnome-shell/extensions/tactile@lundal.io/schemas/org.gnome.shell.extensions.tactile.gschema.xml"
-justper_schema="$HOME/.local/share/gnome-shell/extensions/just-perfection-desktop@just-perfection/schemas/org.gnome.shell.extensions.just-perfection.gschema.xml"
-
-if [ -f $tactile_schema ] && [ -f $justper_schema ]; then
-	#Setup schemas
-	sudo cp $tactile_schema $HOME/.local/share/glib-2.0/schemas
-	sudo cp $justper_schema $HOME/.local/share/glib-2.0/schemas
-	glib-compile-schemas $HOME/.local/share/glib-2.0/schemas/
-
-	# Tactile Setup:
-	gsettings set org.gnome.shell.extensions.tactile col-0 1
-	gsettings set org.gnome.shell.extensions.tactile col-1 2
-	gsettings set org.gnome.shell.extensions.tactile col-2 1
-	gsettings set org.gnome.shell.extensions.tactile col-3 0
-	gsettings set org.gnome.shell.extensions.tactile row-0 1
-	gsettings set org.gnome.shell.extensions.tactile row-1 1
-	gsettings set org.gnome.shell.extensions.tactile gap-size 15
-
-	# Configure Just Perfection
-	gsettings set org.gnome.shell.extensions.just-perfection animation 2
-	gsettings set org.gnome.shell.extensions.just-perfection dash-app-running true
-	gsettings set org.gnome.shell.extensions.just-perfection workspace true
-	gsettings set org.gnome.shell.extensions.just-perfection workspace-popup false
+if [ -f "$HOME/.rhelinit_complete " ]; then
+	printf "\nINFO: Skipping Gnome Extensions. Remove %s to run configuration\n\n" "$HOME/.rhelinit_complete"
 else
-	printf "\n\nTactile and Just Perfection not installed\nInstall them first\n\n"
+	printf "Configuring Gnome Extensions...\n\n"
+
+	tactile_schema="$HOME/.local/share/gnome-shell/extensions/tactile@lundal.io/schemas/org.gnome.shell.extensions.tactile.gschema.xml"
+	justper_schema="$HOME/.local/share/gnome-shell/extensions/just-perfection-desktop@just-perfection/schemas/org.gnome.shell.extensions.just-perfection.gschema.xml"
+
+	if [ -f "$tactile_schema" ] && [ -f "$justper_schema" ]; then
+		#Setup schemas
+		cp "$tactile_schema" "$HOME/.local/share/glib-2.0/schemas"
+		cp "$justper_schema" "$HOME/.local/share/glib-2.0/schemas"
+		glib-compile-schemas "$HOME/.local/share/glib-2.0/schemas/"
+
+		# Tactile Setup:
+		gsettings set org.gnome.shell.extensions.tactile col-0 1
+		gsettings set org.gnome.shell.extensions.tactile col-1 2
+		gsettings set org.gnome.shell.extensions.tactile col-2 1
+		gsettings set org.gnome.shell.extensions.tactile col-3 0
+		gsettings set org.gnome.shell.extensions.tactile row-0 1
+		gsettings set org.gnome.shell.extensions.tactile row-1 1
+		gsettings set org.gnome.shell.extensions.tactile gap-size 15
+
+		# Configure Just Perfection
+		gsettings set org.gnome.shell.extensions.just-perfection animation 2
+		gsettings set org.gnome.shell.extensions.just-perfection dash-app-running true
+		gsettings set org.gnome.shell.extensions.just-perfection workspace true
+		gsettings set org.gnome.shell.extensions.just-perfection workspace-popup false
+	else
+		printf "\n\nTactile and Just Perfection not installed\nInstall them first\n\n"
+	fi
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -4,3 +4,5 @@
 for installer in ./install/*.sh; do source $installer; done
 
 bash ./extras.sh
+
+touch $HOME/.rhelinit_complete


### PR DESCRIPTION
Creates a file in the user's home directory to indicate running initially is completed. This will allow users to get new verstion of the init script to update software without rerunning some of the basic configuration files.

Remove `~/.rhelinit_complete` to rerun the full setup

fixes #13 