### PR TITLE
Add install.sh with install and sha check functions

### DIFF
--- a/install/10_app-wezterm.sh
+++ b/install/10_app-wezterm.sh
@@ -2,28 +2,33 @@
 # Installs Wezterm
 
 wez_config="./config/wezterm.lua"
+version="20240203_110809_5046fc22"
 
-printf "Installing Wezterm..\n\n"
-
-mkdir -p ~/projects/wezterm
-cd ~/projects/wezterm
-wget https://github.com/wez/wezterm/releases/latest/download/wezterm-20240203_110809_5046fc22-1.centos9.x86_64.rpm
-wget https://github.com/wez/wezterm/releases/latest/download/wezterm-20240203_110809_5046fc22-1.centos9.x86_64.rpm.sha256
-if sha256sum -c wezterm-20240203_110809_5046fc22-1.centos9.x86_64.rpm.sha256; then
-	sudo dnf install ./wezterm-20240203_110809_5046fc22-1.centos9.x86_64.rpm -y
+if [ "$(echo $version | tr '_' '-')" == "$(wezterm --version | awk '{print $2}')" ]; then
+	printf "\nINFO: Skipping Wezterm installation. It is already the latest version.\n\n"
 else
-	printf "${red}Checksum failure for Wezterm. Exiting.${normal}\n\n"
-	exit 1
-fi
-cd -
+	printf "Installing Wezterm..\n\n"
 
-cp ./config/wezterm.lua ~/.wezterm.lua
-if [ -f $wez_config ]; then
-	if [ ! -f $HOME/.wezterm.lua ]; then
-		cp $wez_config ~/.wezterm.lua
+	mkdir -p ~/projects/wezterm
+	cd ~/projects/wezterm || exit 3
+	wget "https://github.com/wez/wezterm/releases/latest/download/wezterm-${version}-1.centos9.x86_64.rpm"
+	wget "https://github.com/wez/wezterm/releases/latest/download/wezterm-${version}-1.centos9.x86_64.rpm.sha256"
+	if sha256sum -c "wezterm-$version.centos9.x86_64.rpm.sha256"; then
+		sudo dnf install ./wezterm-$version.centos9.x86_64.rpm -y
 	else
-		printf "\n\nExistin Wezterm config found\n\n"
+		printf "\nERROR:Checksum failure for Wezterm. Exiting.\n\n"
+		exit 1
 	fi
-else
-	printf "\n\nWezterm config not found\n\n"
+	cd - || exit 3
+
+	cp ./config/wezterm.lua ~/.wezterm.lua
+	if [ -f $wez_config ]; then
+		if [ ! -f "$HOME/.wezterm.lua" ]; then
+			cp $wez_config ~/.wezterm.lua
+		else
+			printf "\n\nExistin Wezterm config found\n\n"
+		fi
+	else
+		printf "\n\nWezterm config not found\n\n"
+	fi
 fi

--- a/install/extras/10_app-fzf.sh
+++ b/install/extras/10_app-fzf.sh
@@ -1,26 +1,13 @@
 #!/bin/bash
 # Installs FZF v0.57.0
 
-file_name="fzf_auto.tar.gz"
-proj_dir="$HOME/projects/fzf"
-simlink="$HOME/bin/fzf"
+app_name="fzf"  #This is the name of the application. Should be lower case.
+file_type="tar.gz"  #Defaults to tar.gz, but is used to determine how to uncompress the installation. "tar.XX" and "zip" are valid
+proj_dir="$HOME/projects/$app_name"  #Change if you want installed in a different location
+simlink="$HOME/bin/$app_name"  #Change if you want the executable called something different than $app_name
+url="https://github.com/junegunn/fzf/releases/download/v0.57.0/fzf-0.57.0-linux_amd64.tar.gz"  #URL for the project to get the binaries
+checksum=false  #If you want to check the download's checksum, leave true. Requires the versha variable as the sha256sum to validate against
+versha="empty"
+linker=false #If this package creates a custom folder for each version and you want a consistant path for the symbolic link.
 
-printf "Installing fzf...\n\n"
-
-if [ ! -d $proj_dir ]; then
-	mkdir -p $proj_dir
-fi
-
-cd $proj_dir
-
-wget -O - https://github.com/junegunn/fzf/releases/download/v0.57.0/fzf-0.57.0-linux_amd64.tar.gz > "$file_name"
-
-tar -axf $file_name
-
-if [ -f $simlink ]; then
-	rm $simlink
-fi
-
-ln -s $proj_dir/fzf $simlink
-rm $file_name
-cd -
+install_software "$app_name" "$file_type" "$proj_dir" "$simlink" "$url" "$checksum" "$versha" "$linker"

--- a/install/extras/10_app-glow.sh
+++ b/install/extras/10_app-glow.sh
@@ -1,39 +1,16 @@
 #!/bin/bash
 # Installs Glow v2.0.0
 
-file_name="glow_auto.tar.gz"
-proj_dir="$HOME/projects/glow"
-simlink="$HOME/bin/glow"
+app_name="glow"
+file_type="tar.gz"
+proj_dir="$HOME/projects/$app_name"
+simlink="$HOME/bin/$app_name"
+url="https://github.com/charmbracelet/glow/releases/download/v2.0.0/glow_2.0.0_Linux_x86_64.tar.gz"
+checksum=true
+linker=true
 
-printf "Installing glow...\n\n"
-
-if [ ! -d $proj_dir ]; then
-	mkdir -p $proj_dir
-fi
-
-cd $proj_dir
-
-wget -O - https://github.com/charmbracelet/glow/releases/download/v2.0.0/glow_2.0.0_Linux_x86_64.tar.gz > "$file_name"
 wget https://github.com/charmbracelet/glow/releases/download/v2.0.0/checksums.txt
-shaval=$(sha256sum $file_name | awk '{print $1}')
 versha=$(grep "Linux_x86_64.tar.gz$" checksums.txt | awk '{print $1}')
+rm ./checksums.txt
 
-if [ $versha == $shaval ]; then
-	printf "\n$shaval\n\n"
-	rm $proj_dir/checksums.txt
-else
-	printf "\nIncorrect checksum! Aborting.\n\n"
-	exit 5
-fi
-
-tar -axf $file_name
-
-$HOME/bin/linker.sh glow
-
-if [ -f $simlink ]; then
-	rm $simlink
-fi
-
-ln -s $proj_dir/glow/glow $simlink
-rm $file_name
-cd -
+install_software "$app_name" "$file_type" "$proj_dir" "$simlink" "$url" "$checksum" "$versha" "$linker"

--- a/install/extras/10_app-lazygit.sh
+++ b/install/extras/10_app-lazygit.sh
@@ -1,37 +1,17 @@
 #!/bin/bash
 # Installs Lazygit v0.44.1
 
-file_name="lazygit_auto.tar.gz"
-proj_dir="$HOME/projects/lazygit"
-simlink="$HOME/bin/lazygit"
+app_name="lazygit"  #This is the name of the application. Should be lower case.
+file_type="tar.gz"  #Defaults to tar.gz, but is used to determine how to uncompress the installation. "tar.XX" and "zip" are valid
+proj_dir="$HOME/projects/$app_name"  #Change if you want installed in a different location
+simlink="$HOME/bin/$app_name"  #Change if you want the executable called something different than $app_name
+url="https://github.com/jesseduffield/lazygit/releases/download/v0.44.1/lazygit_0.44.1_Linux_x86_64.tar.gz"  #URL for the project to get the binaries
+checksum=true  #If you want to check the download's checksum, leave true. Requires the versha variable as the sha256sum to validate against
+versha="empty"
+linker=false #If this package creates a custom folder for each version and you want a consistant path for the symbolic link.
 
-printf "Installing Lazygit...\n\n"
-
-if [ ! -d $proj_dir ]; then
-	mkdir -p $proj_dir
-fi
-
-cd $proj_dir
-
-wget -O - https://github.com/jesseduffield/lazygit/releases/download/v0.44.1/lazygit_0.44.1_Linux_x86_64.tar.gz > "$file_name"
 wget https://github.com/jesseduffield/lazygit/releases/download/v0.44.1/checksums.txt
-shaval=$(sha256sum $file_name | awk '{print $1}')
 versha=$(grep "Linux_x86_64" checksums.txt | awk '{print $1}')
+rm ./checksums.txt
 
-if [ $versha == $shaval ]; then
-	printf "\n$shaval\n\n"
-	rm $proj_dir/checksums.txt
-else
-	printf "\nIncorrect checksum! Aborting.\n\n"
-	exit 5
-fi
-
-tar -axf $file_name
-
-if [ -f $simlink ]; then
-	rm $simlink
-fi
-
-ln -s $proj_dir/lazygit $simlink
-rm $file_name
-cd -
+install_software "$app_name" "$file_type" "$proj_dir" "$simlink" "$url" "$checksum" "$versha" "$linker"

--- a/install/extras/10_app-yazi.sh
+++ b/install/extras/10_app-yazi.sh
@@ -1,30 +1,22 @@
 #!/bin/bash
 # Installs Yazi
 
-file_name="yazi_auto.tar.gz"
-proj_dir="$HOME/projects/yazi"
-simlink="$HOME/bin/yazi"
+app_name="yazi"  #This is the name of the application. Should be lower case.
+file_type="zip"  #Defaults to tar.gz, but is used to determine how to uncompress the installation. "tar.XX" and "zip" are valid
+proj_dir="$HOME/projects/$app_name"  #Change if you want installed in a different location
+simlink="$HOME/bin/$app_name"  #Change if you want the executable called something different than $app_name
+url="https://github.com/sxyazi/yazi/releases/latest/download/yazi-x86_64-unknown-linux-gnu.zip"  #URL for the project to get the binaries
+checksum=false  #If you want to check the download's checksum, leave true. Requires the versha variable as the sha256sum to validate against
+versha="empty"
+linker=true #If this package creates a custom folder for each version and you want a consistant path for the symbolic link.
 
-printf "Installing yazi...\n\n"
+install_software "$app_name" "$file_type" "$proj_dir" "$simlink" "$url" "$checksum" "$versha" "$linker"
 
-if [ ! -d $proj_dir ]; then
-	mkdir -p $proj_dir
+#Yazi also has a binary for package management called ya. Lets make sure to make it available too.
+if [ -f "$HOME/bin/ya" ]; then
+	rm "$HOME/bin/ya"
 fi
 
-cd $proj_dir
-
-wget -O - https://github.com/sxyazi/yazi/releases/latest/download/yazi-x86_64-unknown-linux-gnu.zip > "$file_name"
-
-unzip -fo $file_name
-
-$HOME/bin/linker.sh yazi
-
-if [ -f $simlink ]; then
-	rm $simlink
-	rm $HOME/bin/ya
-fi
-
-ln -s $proj_dir/yazi/yazi $simlink
-ln -s $proj_dir/yazi/ya $HOME/bin/ya
-rm $file_name
-cd -
+cd "$proj_dir" || exit 3
+ln -s "$(pwd)/$(find "$app_name"/ -type f -name ya -executable -print 2>|/dev/null)" "$HOME/bin/ya"
+cd - || exit 3

--- a/install/x0_app-template
+++ b/install/x0_app-template
@@ -1,14 +1,19 @@
 #!/bin/bash
-# Installs Bat v0.24.0
+# Installs [Application] [Version if locked]
 
-app_name="bat"  #This is the name of the application. Should be lower case.
+app_name="empty"  #This is the name of the application. Should be lower case.
 file_type="tar.gz"  #Defaults to tar.gz, but is used to determine how to uncompress the installation. "tar.XX" and "zip" are valid
 proj_dir="$HOME/projects/$app_name"  #Change if you want installed in a different location
 simlink="$HOME/bin/$app_name"  #Change if you want the executable called something different than $app_name
-url="https://github.com/sharkdp/bat/releases/download/v0.24.0/bat-v0.24.0-x86_64-unknown-linux-gnu.tar.gz"  #URL for the project to get the binaries
-checksum=false  #If you want to check the download's checksum, leave true. Requires the versha variable as the sha256sum to validate against
+url="empty"  #URL for the project to get the binaries
+checksum=true  #If you want to check the download's checksum, leave true. Requires the versha variable as the sha256sum to validate against
 versha="empty"
 linker=true #If this package creates a custom folder for each version and you want a consistant path for the symbolic link.
+
+# This is an exampl for dynamically getting and setting the sha256sum from a repo.
+wget https://github.com/example/myapp/releases/download/v0.2.4/checksums.txt
+versha=$(grep "Linux_x86_64.tar.gz$" checksums.txt | awk '{print $1}')
+rm ./checksums.txt
 
 # Now we can call the installer function. Requires 8 things
 install_software "$app_name" "$file_type" "$proj_dir" "$simlink" "$url" "$checksum" "$versha" "$linker"

--- a/installer.sh
+++ b/installer.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+is_sha256() {
+    local hash="$1"
+    # SHA-256 hash should be exactly 64 characters long and contain only hexadecimal characters
+    if [[ ${#hash} -eq 64 && "$hash" =~ ^[0-9a-fA-F]{64}$ ]]; then
+        return 0  # Success (is SHA-256)
+    else
+        return 1  # Failure (not SHA-256)
+    fi
+}
+
+install_software() {
+    local app_name=${1:-"empty"}
+    local file_type=${2:-"tar.gz"}
+    local proj_dir=${3:-"empty"}
+    local simlink=${4:-"empty"}
+    local download_url=${5:-"empty"}
+    local checksum=${6:-false}
+    local versha=${7:-"empty"}
+    local linker=${8:-false}
+
+    if [[ "$app_name" == "empty" || "$proj_dir" == "empty" || "$simlink" == "empty" || "$download_url" == "empty" ]]; then
+        printf "\nERROR: App configurations problem.\n\n"
+        exit 25
+    fi
+
+    local file_name="${app_name}_auto.${file_type}"
+
+    printf "Installing %s...\n\n" "$file_name"
+
+    mkdir -p "$proj_dir"
+    cd "$proj_dir" || exit 3
+    wget -O - "$download_url" > "$file_name"
+    
+    if $checksum; then
+        if is_sha256 "$versha"; then
+            shaval=$(sha256sum "$file_name" | awk '{print $1}')
+            if [ "$versha" == "$shaval" ]; then
+                printf "\nValid checksum: %s\n\n" "$shaval"
+            else
+                printf "\nincorrect checksum! aborting.\n\n"
+                printf "expected: %s\n" "$versha"
+                printf "sha256: %s\n" "$shaval"
+                exit 5
+            fi
+        else
+            printf "ERROR: Checksum required, but not passed properly.\n"
+            exit 4
+        fi
+    fi
+
+    if [ "$file_type" == "tar.gz" ]; then
+        tar -axf "$file_name"
+    elif [ "$file_type" == "zip" ]; then
+        unzip -fo "$file_name"
+    else
+        printf "\nERROR: Filetype is invalid: %s\n\n" "$file_type"
+        exit 33
+    fi
+
+    if [ -f "$simlink" ]; then
+	rm "$simlink"
+    fi
+
+    if $linker; then
+        "$HOME/bin/linker.sh" "$app_name"
+        executable="$(pwd)/$(find ${app_name}/ -type f -name ${app_name} -executable -print 2>|/dev/null)"
+    else
+        executable="$(pwd)/$(find . -type f -name $app_name -executable -print 2>|/dev/null)"
+    fi
+
+    ln -s "$executable" "$simlink"
+    rm "$file_name"
+    cd - || exit 3
+
+}
+
+export -f install_software
+export -f is_sha256

--- a/setup.sh
+++ b/setup.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
+source ./installer.sh
+
 #Run stuffs!
-for installer in ./install/*.sh; do source $installer; done
+for installer in ./install/*.sh; do source "$installer"; done
 
 bash ./extras.sh
 
-touch $HOME/.rhelinit_complete
+touch "$HOME/.rhelinit_complete"


### PR DESCRIPTION
Move the basic installation of binaries from github to a single function. This also adds a sha256 check function to make it more sane.

`install_software()` takes 8 variables. There is an app template, `/install/x0_app-template`, to make setting up new app installations easier.

This PR also updates all current github app installations to use this new function.

Move to install function for all extra apps
Move neovim to new installer function
Remove config for neovim setup.

Fixes #12 